### PR TITLE
Subscribe to odometer messages and add odometer observations.

### DIFF
--- a/Config/Config.yaml
+++ b/Config/Config.yaml
@@ -14,6 +14,7 @@ ResultOutputFormat: "TUM" # TUM/KITTI/EUROC
 # sensor switch
 UseGnss: 1
 UseStereo: 1
+UseOdometer: 0
 
 # Sensor calibration path
 DataSourceConfigFilePath: "src/delta_vins/Config/OpenLORIS.yaml"

--- a/Config/OpenLORIS.yaml
+++ b/Config/OpenLORIS.yaml
@@ -22,3 +22,8 @@ ROSTopics:
       TopicQueueSize: 10
       SensorID: 0
       SensorType: "GYRO"
+    - 
+      TopicName: "/odom"
+      TopicQueueSize: 10
+      SensorID: 0
+      SensorType: "Odometer"

--- a/include/Algorithm/Odometer/OdomPreintergration.h
+++ b/include/Algorithm/Odometer/OdomPreintergration.h
@@ -1,0 +1,81 @@
+#pragma once
+#include <sophus/so3.hpp>
+
+#include "utils/typedefs.h"
+#include "utils/tf.h"
+#include "utils/utils.h"
+
+namespace DeltaVins {
+struct OdomPreintergration {
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+    /*
+    MatrixXf CalObservationJacobian(const Matrix3f& R0, const Vector3f& p0,
+                                    const Matrix3f& R1,
+                                    const Vector3f& p1) const {
+        Transform<float> Tbi;
+        Tfs<float>::Instance().GetTransform("body", "imu0", Tbi);
+        Transform<float> Tib = Tbi.Inverse();
+
+        MatrixXf H = MatrixXf::Zero(
+            6, 12);  // order: dobs_dR0, dobs_dp0, dobs_dR1, dobs_dp1
+        H.block<3, 3>(0, 0) = -Tbi.Rotation() * R1.transpose() * R0;
+        H.block<3, 3>(0, 6) = Tbi.Rotation();
+        H.block<3, 3>(3, 0) =
+            crossMat<float>(Tbi.Rotation() * R0.transpose() *
+                            (R1 * Tib.Translation() + p1 - p0)) *
+            Tbi.Rotation();
+        H.block<3, 3>(3, 3) = -Tbi.Rotation() * R0.transpose();
+        H.block<3, 3>(3, 6) = -Tbi.Rotation() * R0.transpose() * R1 *
+                              crossMat<float>(Tib.Translation());
+        H.block<3, 3>(3, 9) = Tbi.Rotation() * R0.transpose();
+
+        // output jacobian of 2D observation [obs_theta, obs_x, obs_y]
+        MatrixXf output_H = MatrixXf::Zero(3, 12);
+        output_H.row(0) = H.row(2);
+        output_H.row(1) = H.row(3);
+        output_H.row(2) = H.row(4);
+        return output_H;
+    }
+
+    VectorXf CalObservationResidual(const Matrix3f& R0, const Vector3f& p0,
+                                    const Matrix3f& R1,
+                                    const Vector3f& p1) const {
+        Transform<float> Tbi;
+        Tfs<float>::Instance().GetTransform("body", "imu0", Tbi);
+        Transform<float> Tib = Tbi.Inverse();
+
+        VectorXf residual = VectorXf::Zero(6);
+        Matrix3f predicted_R =
+            Tbi.Rotation() * R0.transpose() * R1 * Tib.Rotation();
+        Matrix3f observed_R =
+            Eigen::AngleAxisf(dtheta, Vector3f(0.f, 0.f, 1.f)).matrix();
+        residual.head<3>() =
+            Sophus::SO3f(observed_R * predicted_R.transpose()).log();
+        Vector3f predicted_P = Tbi.Rotation() * R0.transpose() *
+                                   (R1 * Tib.Translation() + p1 - p0) -
+                               Tbi.Rotation() * Tib.Translation();
+        Vector3f observed_P = Vector3f(dx, dy, 0.f);
+        residual.tail<3>() = observed_P - predicted_P;
+
+        // output residual of 2D observation [obs_theta, obs_x, obs_y]
+        VectorXf output_residual = VectorXf::Zero(3);
+        output_residual(0) = residual(2);
+        output_residual(1) = residual(3);
+        output_residual(2) = residual(4);
+        return output_residual;
+    }
+    */
+
+    int sensor_id{0};
+    int64_t t0{0};  // first data timestamp
+    int64_t t1{0};  // last data timestamp
+    int64_t dT{0};  // delta time
+
+    // 2D observation; coordinate frame: forward, left, upward
+    float dtheta{0.f};               // delta theta
+    float dx{0.f};                   // delta position x
+    float dy{0.f};                   // delta position y
+    Matrix3f cov{Matrix3f::Zero()};  // covariance matrix, order: theta,x,y
+};
+}  // namespace DeltaVins

--- a/include/Algorithm/VIOAlgorithm.h
+++ b/include/Algorithm/VIOAlgorithm.h
@@ -1,14 +1,14 @@
 #pragma once
 
-#include <FrameAdapter.h>
-#include <WorldPointAdapter.h>
-
+#include "FrameAdapter.h"
+#include "WorldPointAdapter.h"
 #include "IMU/ImuPreintergration.h"
 #include "dataStructure/IO_Structures.h"
 #include "solver/SquareRootEKFSolver.h"
 #include "vision/FeatureTrackerOpticalFlow.h"
 #include "vision/FeatureTrackerOpticalFlow_Chen.h"
 #include "Initializer/StaticInitializer.h"
+
 namespace DeltaVins {
 class VIOAlgorithm {
    public:

--- a/include/Algorithm/solver/SquareRootEKFSolver.h
+++ b/include/Algorithm/solver/SquareRootEKFSolver.h
@@ -42,6 +42,8 @@ class SquareRootEKFSolver {
 
     void AddVelocityConstraint();
 
+    void AddOdomVelocityConstraint();
+
     int _AddPlaneContraint();
     int StackInformationFactorMatrix();
 

--- a/include/IO/dataBuffer/OdometerBuffer.h
+++ b/include/IO/dataBuffer/OdometerBuffer.h
@@ -1,0 +1,32 @@
+#pragma once
+#include "IO/dataSource/dataSource.h"
+#include "dataStructure/ringBuffer.h"
+
+namespace DeltaVins {
+struct OdomPreintergration;
+
+class OdometerBuffer : public CircularBuffer<OdometerData, 10>,
+                       public DataSource::OdometerObserver {
+   public:
+    friend class DataRecorder;
+    static OdometerBuffer& Instance() {
+        static OdometerBuffer odom_buffer;
+        return odom_buffer;
+    }
+    ~OdometerBuffer() = default;
+
+    void OnOdometerReceived(const OdometerData& odometerData) override;
+
+    // bool OdomPreIntegration(int64_t start_t, int64_t end_t,
+    //                         OdomPreintergration* odom_term) const;
+
+    bool OdomVelocity(int64_t query_time, float* velocity) const;
+
+   private:
+    OdometerBuffer();
+
+    Matrix2f odom_noise_cov_{
+        Matrix2f::Zero()};  // order: angular_velocity, velocity
+};
+
+}  // namespace DeltaVins

--- a/include/IO/dataSource/dataSource_ROS2.h
+++ b/include/IO/dataSource/dataSource_ROS2.h
@@ -5,11 +5,12 @@
 #include <rosbag2_cpp/reader.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp/serialization.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <sensor_msgs/msg/image.hpp>
+#include <sensor_msgs/msg/imu.hpp>
+#include <sensor_msgs/msg/nav_sat_fix.hpp>
 
 #include "dataSource.h"
-#include "sensor_msgs/msg/image.hpp"
-#include "sensor_msgs/msg/imu.hpp"
-#include "sensor_msgs/msg/nav_sat_fix.hpp"
 
 namespace DeltaVins {
 class DataSource_ROS2 : public DataSource, public rclcpp::Node {
@@ -35,6 +36,8 @@ class DataSource_ROS2 : public DataSource, public rclcpp::Node {
                         StereoType type, int sensor_id);
     void NavSatFixCallback(const sensor_msgs::msg::NavSatFix::SharedPtr msg,
                            int sensor_id);
+    void OdometerCallback(const nav_msgs::msg::Odometry::SharedPtr msg,
+                          int sensor_id);
 
    private:
     std::vector<rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr>
@@ -42,6 +45,9 @@ class DataSource_ROS2 : public DataSource, public rclcpp::Node {
 
     std::vector<rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr>
         imu_sub_;
+
+    std::vector<rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr>
+        odom_sub_;
 
     // TODO: only support one stereo camera now
     std::pair<rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr,
@@ -66,6 +72,7 @@ class DataSource_ROS2 : public DataSource, public rclcpp::Node {
     rclcpp::Serialization<sensor_msgs::msg::Image> image_serializer_;
     rclcpp::Serialization<sensor_msgs::msg::Imu> imu_serializer_;
     rclcpp::Serialization<sensor_msgs::msg::NavSatFix> nav_sat_fix_serializer_;
+    rclcpp::Serialization<nav_msgs::msg::Odometry> odom_serializer_;
     ImageData::Ptr image_data_cache_;
 };
 }  // namespace DeltaVins

--- a/include/dataStructure/sensorStructure.h
+++ b/include/dataStructure/sensorStructure.h
@@ -51,7 +51,7 @@ struct NavSatFixData {
 
 struct OdometerData {
     int64_t timestamp{0};
-
+    int sensor_id{0};
     int encoderL{0};
     int encoderR{0};
     float dEncoderL{0.f};
@@ -59,6 +59,12 @@ struct OdometerData {
 
     float velocity{0.f};
     float angularVelocity{0.f};
+
+    bool operator<(int64_t t) { return timestamp < t; }
+    bool operator>(int64_t t) { return timestamp > t; }
+    bool operator==(int64_t t) { return timestamp == t; }
+    bool operator<=(int64_t t) { return timestamp <= t; }
+    bool operator>=(int64_t t) { return timestamp >= t; }
 };
 
 }  // namespace DeltaVins

--- a/include/utils/Config.h
+++ b/include/utils/Config.h
@@ -10,7 +10,15 @@ enum DataSrcType {
     DataSrcROS2_bag
 };
 
-enum class ROS2SensorType { MonoCamera, StereoCamera, IMU, ACC, GYRO, GNSS };
+enum class ROS2SensorType {
+    MonoCamera,
+    StereoCamera,
+    IMU,
+    ACC,
+    GYRO,
+    GNSS,
+    ODOMETER
+};
 
 struct ROS2SensorTopic {
     ROS2SensorType type;
@@ -60,6 +68,7 @@ struct Config {
     static std::vector<ROS2SensorTopic> ROS2SensorTopics;
     static bool UseGnss;
     static bool UseStereo;
+    static bool UseOdometer;
     static bool UseBackTracking;
 };
 }  // namespace DeltaVins

--- a/launch/launch.py
+++ b/launch/launch.py
@@ -11,6 +11,12 @@ def generate_launch_description():
     rviz_config_file = os.path.join(delta_vins_share_dir, 'rviz', 'delta_vins.rviz')
     config_file_path = os.path.join(delta_vins_share_dir, 'Config', 'Config.yaml')
 
+    declare_data_source_path_arg = DeclareLaunchArgument(
+        'DataSourcePath',
+        default_value='',
+        description='Path to the input dataset'
+    )
+
     rviz2_node = Node(
         package='rviz2',
         executable='rviz2',
@@ -18,12 +24,15 @@ def generate_launch_description():
         arguments=['-d', rviz_config_file],
     )
     delta_vins_node = Node(
-            package='delta_vins',
-            executable='RunDeltaVINS',
-            name='RunDeltaVINS',
-            arguments=[config_file_path]
-        )
+        package='delta_vins',
+        executable='RunDeltaVINS',
+        name='RunDeltaVINS',
+        parameters=[{"DataSourcePath": LaunchConfiguration("DataSourcePath")}],
+        arguments=[config_file_path]
+    )
+
     return LaunchDescription([
+        declare_data_source_path_arg,
         rviz2_node,
         delta_vins_node,
     ])

--- a/src/IO/dataBuffer/OdometerBuffer.cpp
+++ b/src/IO/dataBuffer/OdometerBuffer.cpp
@@ -1,0 +1,143 @@
+#include "IO/dataBuffer/OdometerBuffer.h"
+
+#include "Algorithm/Odometer/OdomPreintergration.h"
+#include "utils/utils.h"
+
+namespace DeltaVins {
+
+OdometerBuffer::OdometerBuffer() {
+    float angular_velocity_noise = 0.05f;
+    float velocity_noise = 0.5f;
+    odom_noise_cov_(0, 0) = angular_velocity_noise * angular_velocity_noise;
+    odom_noise_cov_(1, 1) = velocity_noise * velocity_noise;
+}
+
+void OdometerBuffer::OnOdometerReceived(const OdometerData& odometerData) {
+    getHeadNode() = odometerData;
+    PushIndex();
+}
+
+/*
+bool OdometerBuffer::OdomPreIntegration(int64_t start_t, int64_t end_t,
+                                        OdomPreintergration* odom_term) const {
+    if (end_t <= start_t) {
+        LOGE("input timestamp disorder, start time:%lld end time:%lld",
+             (long long)start_t, (long long)end_t);
+        return false;
+    }
+    int index0 = binarySearch<long long>(start_t, Left);
+    if (index0 < 0) {
+        LOGE("start time querying odometer buffer failed, start time:%lld",
+             (long long)start_t);
+        return false;
+    }
+    int index1 = binarySearch<long long>(end_t, Left);
+    for (int i = 0; i < 5 && index1 < 0; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        index1 = binarySearch<long long>(end_t, Left);
+        LOGI("waiting for odom, %d", i);
+    }
+    if (index1 < 0) {
+        LOGE("end time querying odometer buffer failed, end time:%lld",
+             (long long)end_t);
+        return false;
+    }
+    if (index0 == index1) {
+        LOGW("no enough odometer data for preintegration.");
+        return false;
+    }
+
+    odom_term->t0 = start_t;
+    odom_term->t1 = end_t;
+
+    int index = index0;
+    int index_end = getDeltaIndex(index1, 1);
+    float dt = 0.f;
+    int cnt = 0;
+    while (index != index_end) {
+        float velocity = 0.f;
+        float angular_velocity = 0.f;
+
+        auto& odom_data = buf_[index];
+        int nextIndex = getDeltaIndex(index, 1);
+        auto& next_odom_data = buf_[nextIndex];
+        if (index == index0) {
+            dt = (next_odom_data.timestamp - odom_term->t0) * 1e-9;
+            float a = next_odom_data.timestamp - odom_term->t0;
+            float b = next_odom_data.timestamp - odom_data.timestamp;
+            float k = a / b;
+            velocity = linearInterpolate(odom_data.velocity,
+                                         next_odom_data.velocity, 1 - k);
+            angular_velocity =
+                linearInterpolate(odom_data.angularVelocity,
+                                  next_odom_data.angularVelocity, 1 - k);
+        } else if (index == index1) {
+            dt = (odom_term->t1 - odom_data.timestamp) * 1e-9;
+            float a = next_odom_data.timestamp - odom_term->t1;
+            float b = next_odom_data.timestamp - odom_data.timestamp;
+            float k = a / b;
+            velocity = linearInterpolate(odom_data.velocity,
+                                         next_odom_data.velocity, k);
+            angular_velocity = linearInterpolate(
+                odom_data.angularVelocity, next_odom_data.angularVelocity, k);
+        } else {
+            dt = (next_odom_data.timestamp - odom_data.timestamp) * 1e-9;
+            velocity = (odom_data.velocity + next_odom_data.velocity) * 0.5f;
+            angular_velocity =
+                (odom_data.angularVelocity + next_odom_data.angularVelocity) *
+                0.5f;
+        }
+
+        Matrix3f F = Matrix3f::Identity();
+        F(1, 0) = -velocity * dt * std::sin(odom_term->dtheta);
+        F(2, 0) = velocity * dt * std::cos(odom_term->dtheta);
+
+        MatrixXf G = MatrixXf::Zero(3, 2);
+        G(0, 0) = dt * dt;
+        G(1, 1) = dt * std::cos(odom_term->dtheta);
+        G(2, 1) = dt * std::sin(odom_term->dtheta);
+
+        odom_term->cov = F * odom_term->cov * F.transpose() +
+                         G * odom_noise_cov_ * G.transpose();
+
+        odom_term->dtheta += angular_velocity * dt;
+        odom_term->dx += velocity * dt * std::cos(odom_term->dtheta);
+        odom_term->dy += velocity * dt * std::sin(odom_term->dtheta);
+
+        index = nextIndex;
+        ++cnt;
+    }
+
+    odom_term->dT += odom_term->t1 - odom_term->t0;
+
+    return true;
+}
+*/
+
+bool OdometerBuffer::OdomVelocity(int64_t query_time, float* velocity) const {
+    int index_left = binarySearch<long long>(query_time, Left);
+    if (index_left < 0) {
+        LOGE("time querying odometer buffer failed, time:%lld",
+             (long long)query_time);
+        return false;
+    }
+    const auto& odom_data_left = buf_[index_left];
+
+    int index_right = getDeltaIndex(index_left, 1);
+    if (index_right > 0) {
+        const auto& odom_data_right = buf_[index_right];
+        float a = query_time - odom_data_left.timestamp;
+        float b = odom_data_right.timestamp - odom_data_left.timestamp;
+        float k = a / b;
+        *velocity = linearInterpolate(odom_data_left.velocity,
+                                      odom_data_right.velocity, k);
+    } else if ((query_time - odom_data_left.timestamp) * 1e-6 < 10.0) {
+        *velocity = odom_data_left.velocity;
+    } else {
+        return false;
+    }
+
+    return true;
+}
+
+}  // namespace DeltaVins

--- a/src/framework/slamAPI.cpp
+++ b/src/framework/slamAPI.cpp
@@ -10,12 +10,11 @@
 #if ENABLE_VISUALIZER
 #include "../../SlamVisualizer/SlamVisualizer.h"
 #elif ENABLE_VISUALIZER_TCP
-#include <IO/dataOuput/PoseOutputTCP.h>
+#include "IO/dataOuput/PoseOutputTCP.h"
 #endif
 
-#include <IO/dataOuput/DataOutputROS.h>
-#include <IO/dataOuput/DataRecorder.h>
-
+#include "IO/dataOuput/DataOutputROS.h"
+#include "IO/dataOuput/DataRecorder.h"
 #include "IO/dataSource/dataSource_Synthetic.h"
 #include "utils/TickTock.h"
 
@@ -24,6 +23,7 @@
 #endif
 
 #include "IO/dataBuffer/GnssBuffer.h"
+#include "IO/dataBuffer/OdometerBuffer.h"
 #include "utils/SensorConfig.h"
 
 using namespace DeltaVins;
@@ -122,6 +122,9 @@ bool InitSlamSystem(const char* configFile) {
     dataSourcePtr->AddImuObserver(&ImuBuffer::Instance());
     if (Config::UseGnss) {
         dataSourcePtr->AddNavSatFixObserver(&GnssBuffer::Instance());
+    }
+    if (Config::UseOdometer) {
+        dataSourcePtr->AddOdometerObserver(&OdometerBuffer::Instance());
     }
 
     return true;

--- a/src/utils/Config.cpp
+++ b/src/utils/Config.cpp
@@ -57,6 +57,7 @@ int Config::MaxNumToTrack;
 int Config::MaskSize;
 bool Config::UseGnss;
 bool Config::UseStereo;
+bool Config::UseOdometer;
 bool Config::UseBackTracking;
 std::vector<ROS2SensorTopic> Config::ROS2SensorTopics;
 int Config::FastScoreThreshold;
@@ -143,6 +144,7 @@ bool Config::loadConfigFile(const std::string& configFile) {
     config_file_cv["MaskSize"] >> MaskSize;
     config_file_cv["UseGnss"] >> UseGnss;
     config_file_cv["UseStereo"] >> UseStereo;
+    config_file_cv["UseOdometer"] >> UseOdometer;
     config_file_cv["UseBackTracking"] >> UseBackTracking;
     config_file_cv["FastScoreThreshold"] >> FastScoreThreshold;
 
@@ -182,6 +184,8 @@ bool Config::loadConfigFile(const std::string& configFile) {
                 topic.type = ROS2SensorType::GYRO;
             } else if (topic_type == "GNSS") {
                 topic.type = ROS2SensorType::GNSS;
+            } else if (topic_type == "Odometer") {
+                topic.type = ROS2SensorType::ODOMETER;
             } else {
                 throw std::runtime_error("Unknown ROS2 topic type: " +
                                          topic_type);
@@ -193,6 +197,13 @@ bool Config::loadConfigFile(const std::string& configFile) {
                 topic.topics.push_back(topic_name);
             }
             (*it)["TopicQueueSize"] >> topic.queue_size;
+
+            if ((topic.type == ROS2SensorType::GNSS && !Config::UseGnss) ||
+                (topic.type == ROS2SensorType::ODOMETER &&
+                 !Config::UseOdometer)) {
+                continue;
+            }
+
             ROS2SensorTopics.push_back(topic);
         }
     }

--- a/testScripts/batch_run.py
+++ b/testScripts/batch_run.py
@@ -1,0 +1,148 @@
+#!/usr/bin/python3
+
+import sys
+import os
+import time
+import argparse
+import json
+from pathlib import Path
+import pandas as pd
+
+# each dataset contains a tuple of (ros2 data path, ground truth path)
+OpenLORIS_dataset = [
+    ("/dataset/SLAM/OpenLORIS/cafe1-2/ros2",
+     "/dataset/SLAM/OpenLORIS/cafe1-2/non-ros/groundtruth.txt"),
+    ("/dataset/SLAM/OpenLORIS/corridor1-1/ros2",
+     "/dataset/SLAM/OpenLORIS/corridor1-1/non-ros/groundtruth.txt"),
+    ("/dataset/SLAM/OpenLORIS/corridor1-2/ros2",
+     "/dataset/SLAM/OpenLORIS/corridor1-2/non-ros/groundtruth.txt"),
+    ("/dataset/SLAM/OpenLORIS/corridor1-3/ros2",
+     "/dataset/SLAM/OpenLORIS/corridor1-3/non-ros/groundtruth.txt"),
+    ("/dataset/SLAM/OpenLORIS/corridor1-4/ros2",
+     "/dataset/SLAM/OpenLORIS/corridor1-4/non-ros/groundtruth.txt"),
+    ("/dataset/SLAM/OpenLORIS/corridor1-5/ros2",
+     "/dataset/SLAM/OpenLORIS/corridor1-5/non-ros/groundtruth.txt")
+]
+Euroc_dataset = [
+    ("/dataset/SLAM/EuRoc/V1_01_easy/ros2",
+     "/dataset/SLAM/EuRoc/V1_01_easy/mav0/state_groundtruth_estimate0/data.tum"),
+    ("/dataset/SLAM/EuRoc/V1_03_difficult/ros2",
+     "/dataset/SLAM/EuRoc/V1_03_difficult/mav0/state_groundtruth_estimate0/data.tum"),
+    ("/dataset/SLAM/EuRoc/MH_01_easy/ros2",
+     "/dataset/SLAM/EuRoc/MH_01_easy/mav0/state_groundtruth_estimate0/data.tum"),
+    ("/dataset/SLAM/EuRoc/MH_04_difficult/ros2",
+     "/dataset/SLAM/EuRoc/MH_04_difficult/mav0/state_groundtruth_estimate0/data.tum")
+]
+
+
+def DoCommand(cmd: str):
+    print(
+        'Running command: {}'.format(cmd))
+    os.system(cmd)
+
+
+def ParseArg():
+    parser = argparse.ArgumentParser(description=(
+        'Run the system and evaluate results. '
+        'Usage example: python3 batch_run.py euroc ./TestResults --test_name my_test'),
+        formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument(
+        'dataset', help='dataset name, euroc or openloris', type=str)
+    parser.add_argument('running_result_path',
+                        help='path to the system running results', type=str)
+    parser.add_argument('--test_name', help='test name', type=str)
+
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = ParseArg()
+    if args.dataset == 'euroc':
+        dataset = Euroc_dataset
+    elif args.dataset == 'openloris':
+        dataset = OpenLORIS_dataset
+    else:
+        print('dataset name invalid !')
+        sys.exit(1)
+
+    base_result_path = os.path.abspath(args.running_result_path)
+    test_time = time.strftime('%Y-%m-%d-%H-%M', time.localtime())
+    test_name = ''
+    if args.test_name is not None:
+        test_name = args.test_name
+    test_folder_name = test_time + '_' + test_name
+    for item in dataset:
+        # run SLAM on the dataset
+        data = item[0]
+        ground_truth = item[1]
+        shell_command = 'nohup ros2 launch delta_vins launch.py DataSourcePath:={} &'.format(
+            data)
+        DoCommand(shell_command)
+
+        # wait for running process to finish
+        log_file = os.path.expanduser('~/.ros/log/latest/launch.log')
+        log_file_size = 0
+        while True:
+            time.sleep(10)
+            # check if log file size is increasing
+            if os.path.exists(log_file):
+                new_file_size = os.path.getsize(log_file)
+                if new_file_size > log_file_size:
+                    log_file_size = new_file_size
+                else:
+                    print('log file size stop increasing, file size: {}'.format(
+                        log_file_size))
+                    shell_command = 'pkill -f "delta_vins"'
+                    DoCommand(shell_command)
+                    break
+            else:
+                print('log file {} not found !'.format(log_file))
+                shell_command = 'pkill -f "delta_vins"'
+                DoCommand(shell_command)
+                sys.exit(1)
+
+        # collect running results
+        result_path = os.path.join(
+            base_result_path, args.dataset, test_folder_name, os.path.basename(os.path.dirname(data)))
+        shell_command = 'mkdir -p {}'.format(result_path)
+        DoCommand(shell_command)
+        shell_command = 'cp {} {}'.format(os.path.join(
+            base_result_path, 'outputPose.tum'), result_path)
+        DoCommand(shell_command)
+        real_log_file = Path(log_file).resolve()
+        shell_command = 'cp {} {}'.format(real_log_file, result_path)
+        DoCommand(shell_command)
+
+        # evaluate results
+        shell_command = 'evo_rpe tum {} {} -d 15 -u f -r full --save_results {}'.format(
+            ground_truth, os.path.join(result_path, 'outputPose.tum'), os.path.join(result_path, 'results.zip'))
+        DoCommand(shell_command)
+        shell_command = 'unzip {} {} -d {}'.format(
+            os.path.join(result_path, 'results.zip'), 'stats.json', result_path)
+        DoCommand(shell_command)
+
+    # collect evaluation results
+    evaluation_list = []
+    for root, dirs, files in os.walk(os.path.join(
+            base_result_path, args.dataset, test_folder_name)):
+        if 'stats.json' in files:
+            with open(os.path.join(root, 'stats.json'), 'r') as f:
+                evaluation = json.load(f)
+            evaluation_list.append((os.path.basename(root), evaluation))
+    evaluation_list = [{"Dataset": name, **info}
+                       for name, info in evaluation_list]
+    df = pd.DataFrame(evaluation_list)
+    print('\ntest:', test_name, '\n', df)
+
+    with open(os.path.join(
+            base_result_path, args.dataset, test_folder_name, "evaluations.csv"), "w", encoding="utf-8") as f:
+        test_name = ''
+        if args.test_name is not None:
+            test_name = args.test_name
+        f.write("Test: {} \n".format(test_name))
+        df.to_csv(f, index=False)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Key updates
1. Subscribe to odometer messages.
2. Add odometer velocity observation to filter.
3. Implement odometer preintegration. They are commented out, because the filter will diverge after adding this observation. I need to spend some time checking whether the issue is with the pre-integration calculation or with adding the observation to the filter.

## Test
RPE on OpenLORIS dataset
<img width="606" alt="image" src="https://github.com/user-attachments/assets/1fe8f816-e892-4c5a-8f09-257270ecb66b" />
1. Adding odometer velocity observation improves the robustness of both mono-VIO and stereo-VIO.  Pure VIO diverged on certain datasets.
2. Adding odometer velocity observation improves the accuracy of mono-VIO.
3. The current version of VIO performs poorly in terms of accuracy on OpenLORIS dataset. The cause needs to be investigated further. As a comparison, here is the accuracy performance on the EuRoC dataset:
<img width="426" alt="image" src="https://github.com/user-attachments/assets/84048c00-723b-4df4-9bae-ae1aa41fe572" />








